### PR TITLE
Switch out environment variable lookup function for map in `cli` struct

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -51,7 +51,7 @@ type authCmd struct {
 type authStatusCmd struct{}
 
 func (c *authStatusCmd) Run(ctx context.Context, k *kong.Kong, global *cli) error {
-	token, err := gitHubToken(ctx, global.lookupEnv, global.lookPath)
+	token, err := gitHubToken(ctx, global.environ, global.lookPath)
 	if err != nil {
 		return err
 	}
@@ -80,13 +80,13 @@ func (c *authGitHubLoginCmd) Run(ctx context.Context, k *kong.Kong, global *cli)
 	var configHome string
 	if runtime.GOOS == "windows" {
 		var err error
-		configHome, err = windowsConfigHome(global.lookupEnv)
+		configHome, err = windowsConfigHome(lookupEnvMapFunc(global.environ))
 		if err != nil {
 			return err
 		}
 	} else {
 		var err error
-		configHome, err = (&xdgdir.Dirs{Getenv: global.lookupEnv.get}).ConfigHome()
+		configHome, err = (&xdgdir.Dirs{Getenv: lookupEnvMapFunc(global.environ).get}).ConfigHome()
 		if err != nil {
 			return err
 		}
@@ -126,14 +126,14 @@ func (c *authGitHubLoginCmd) Run(ctx context.Context, k *kong.Kong, global *cli)
 }
 
 // gitHubToken obtains a GitHub personal access token from the environment.
-func gitHubToken(ctx context.Context, lookupEnv lookupEnvFunc, lookPath lookPathFunc) (string, error) {
+func gitHubToken(ctx context.Context, environ map[string]string, lookPath lookPathFunc) (string, error) {
 	const varName = "GITHUB_TOKEN"
 
-	if token := lookupEnv.get(varName); token != "" {
+	if token := environ[varName]; token != "" {
 		return token, nil
 	}
 
-	if tokenData, err := readConfigFile(lookupEnv, "github-token"); err == nil {
+	if tokenData, err := readConfigFile(lookupEnvMapFunc(environ), "github-token"); err == nil {
 		return string(bytes.TrimSpace(tokenData)), nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", err
@@ -148,6 +148,7 @@ func gitHubToken(ctx context.Context, lookupEnv lookupEnvFunc, lookPath lookPath
 		return "", fmt.Errorf("gh auth token: %v", err)
 	}
 	cmd := exec.CommandContext(ctx, ghExe, "auth", "token", "--hostname=github.com")
+	cmd.Env = environMapToSlice(environ)
 	cmd.Cancel = func() error { return sigterm.CancelProcess(cmd.Process) }
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr

--- a/auth_test.go
+++ b/auth_test.go
@@ -39,13 +39,9 @@ func TestAuthGitHubLoginCmd(t *testing.T) {
 	configHome := t.TempDir()
 	c := &cli{
 		stdin: strings.NewReader(fakeToken + "\n"),
-		lookupEnv: func(key string) (string, bool) {
-			switch key {
-			case "XDG_CONFIG_HOME", "AppData":
-				return configHome, true
-			default:
-				return "", false
-			}
+		environ: map[string]string{
+			"XDG_CONFIG_HOME": configHome,
+			"AppData":         configHome,
 		},
 		lookPath: stubLookPath,
 	}
@@ -152,13 +148,8 @@ func TestGitHubToken(t *testing.T) {
 				t.Skip("Skip on Windows")
 			}
 
-			lookupEnv := lookupEnvFunc(func(key string) (string, bool) {
-				v, ok := test.env[key]
-				return v, ok
-			})
 			lookPath := lookPathFunc(stubLookPath)
-
-			got, err := gitHubToken(context.Background(), lookupEnv, lookPath)
+			got, err := gitHubToken(context.Background(), test.env, lookPath)
 			if test.err && err == nil {
 				t.Errorf("gitHubToken(...) = %q, <nil>; want _, <error>", got)
 			} else if !test.err && (got != test.want || err != nil) {

--- a/editor_test.go
+++ b/editor_test.go
@@ -123,16 +123,6 @@ func editorCommand(tb testing.TB, content []byte) (*jujutsu.CommandNameAndArgs, 
 	return jujutsu.CommandArgv(cpPath, []string{fname}, environMap()), nil
 }
 
-func environMap() map[string]string {
-	environ := os.Environ()
-	m := make(map[string]string, len(environ))
-	for _, kv := range environ {
-		k, v, _ := strings.Cut(kv, "=")
-		m[k] = v
-	}
-	return m
-}
-
 var findCopyProgram = sync.OnceValues(func() (string, error) {
 	if runtime.GOOS == "windows" {
 		return "cp", nil

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/alecthomas/kong"
 	"golang.org/x/term"
@@ -41,9 +42,9 @@ import (
 )
 
 type cli struct {
-	stdin     io.Reader     `kong:"-"`
-	lookupEnv lookupEnvFunc `kong:"-"`
-	lookPath  lookPathFunc  `kong:"-"`
+	stdin    io.Reader         `kong:"-"`
+	environ  map[string]string `kong:"-"`
+	lookPath lookPathFunc      `kong:"-"`
 
 	Submit submitCmd `kong:"cmd,default=withargs,help=Submit a review stack"`
 	Auth   authCmd   `kong:"cmd,help=Manage credentials"`
@@ -51,9 +52,9 @@ type cli struct {
 
 func main() {
 	c := &cli{
-		stdin:     os.Stdin,
-		lookupEnv: os.LookupEnv,
-		lookPath:  exec.LookPath,
+		stdin:    os.Stdin,
+		environ:  environMap(),
+		lookPath: exec.LookPath,
 	}
 	k := kong.Parse(c, kong.UsageOnError())
 	ctx, cancel := sigterm.NotifyContext(context.Background())
@@ -69,6 +70,16 @@ func main() {
 // The de facto implementation of lookupEnvFunc is [os.LookupEnv],
 // but others exist for testing.
 type lookupEnvFunc func(key string) (string, bool)
+
+// lookupEnvMapFunc returns a [lookupEnvFunc]
+// that looks up environment variables
+// from the given map.
+func lookupEnvMapFunc(m map[string]string) lookupEnvFunc {
+	return func(key string) (string, bool) {
+		v, ok := m[key]
+		return v, ok
+	}
+}
 
 // get retrieves the environment variable named by the key.
 // It returns the value, which will be empty if the variable is not present.
@@ -133,4 +144,25 @@ const (
 func isTerminal(f io.Writer) bool {
 	osFile, ok := f.(*os.File)
 	return ok && term.IsTerminal(int(osFile.Fd()))
+}
+
+// environMap returns the environment variables as a map.
+func environMap() map[string]string {
+	environ := os.Environ()
+	m := make(map[string]string, len(environ))
+	for _, kv := range environ {
+		k, v, _ := strings.Cut(kv, "=")
+		m[k] = v
+	}
+	return m
+}
+
+// environMapToSlice returns a slice of strings for each entry in m in the format "key=value".
+// The order is undefined.
+func environMapToSlice(m map[string]string) []string {
+	slice := make([]string, 0, len(m))
+	for k, v := range m {
+		slice = append(slice, k+"="+v)
+	}
+	return slice
 }

--- a/submit.go
+++ b/submit.go
@@ -60,7 +60,9 @@ func (c *submitCmd) Run(ctx context.Context, k *kong.Kong, global *cli) error {
 		return fmt.Errorf("cannot combine --no-push with --change")
 	}
 
-	jj, err := jujutsu.New(jujutsu.Options{})
+	jj, err := jujutsu.New(jujutsu.Options{
+		Env: environMapToSlice(global.environ),
+	})
 	if err != nil {
 		return err
 	}
@@ -159,7 +161,7 @@ func (c *submitCmd) Run(ctx context.Context, k *kong.Kong, global *cli) error {
 		return fmt.Errorf("push remote: %v", err)
 	}
 
-	token, err := gitHubToken(ctx, global.lookupEnv, global.lookPath)
+	token, err := gitHubToken(ctx, global.environ, global.lookPath)
 	if err != nil {
 		if !c.DryRun {
 			return err


### PR DESCRIPTION
When we execute subprocesses, we need to inherit environment variables. This means we need to know the total set.

Updates #40

<!-- jj-domino -->
<!-- Do not remove this comment! Everything in this section will be rewritten by jj-domino. -->

## Related Pull Requests

This pull request is part of a stack managed by [jj-domino](https://github.com/zombiezen/jj-domino):

 1. *→ this pull request ←*
 2. #49
 3. #50
