### PR TITLE
Replicate Jujutsu default `trunk()` logic

### DIFF
--- a/internal/jujutsu/jj.go
+++ b/internal/jujutsu/jj.go
@@ -220,6 +220,11 @@ type Bookmark struct {
 	TargetMerge Merge[CommitID] `json:"target"`
 }
 
+// RefSymbol returns the ref symbol that represents the bookmark.
+func (b *Bookmark) RefSymbol() RefSymbol {
+	return RefSymbol{Name: b.Name, Remote: b.Remote}
+}
+
 func (jj *Jujutsu) ListBookmarks(ctx context.Context) ([]*Bookmark, error) {
 	out, err := jj.command(ctx, "bookmark", "list", "--all", "--ignore-working-copy", "--template", "json(self)").Output()
 	if err != nil {

--- a/jj_helpers.go
+++ b/jj_helpers.go
@@ -31,6 +31,8 @@ import (
 	"slices"
 	"strings"
 
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
 	"zombiezen.com/go/jj-domino/internal/jujutsu"
 )
 
@@ -99,6 +101,57 @@ func jjGitPush(ctx context.Context, jj *jujutsu.Jujutsu, w io.Writer, dryRun boo
 		return fmt.Errorf("jj git push --remote=%s: %v", pushRemoteName, err)
 	}
 	return nil
+}
+
+// resolveTrunk attempts to determine the [jujutsu.RefSymbol] that the trunk() revset uses.
+// This isn't a well-defined operation in Jujutsu because trunk() is a revset,
+// so resolveTrunk makes a best effort to resolve most common scenarios.
+func resolveTrunk(settings map[string]jsontext.Value, bookmarks []*jujutsu.Bookmark) (jujutsu.RefSymbol, error) {
+	const key = `revset-aliases."trunk()"`
+	if definition := settings[key]; len(definition) > 0 {
+		var revset string
+		if err := jsonv2.Unmarshal(definition, &revset); err != nil {
+			return jujutsu.RefSymbol{}, fmt.Errorf("parse jj config get %s: %v", key, err)
+		}
+		refSymbol, err := jujutsu.ParseRefSymbol(revset)
+		if err != nil {
+			return jujutsu.RefSymbol{}, fmt.Errorf("parse jj config get %s: %s: %v", key, revset, err)
+		}
+		return refSymbol, nil
+	}
+
+	// Built-in trunk() is defined here:
+	// https://github.com/jj-vcs/jj/blob/v0.39.0/cli/src/config/revsets.toml#L21-L31
+	possible := make([]*jujutsu.Bookmark, 0, 6)
+	for _, b := range bookmarks {
+		if _, ok := b.TargetMerge.Resolved(); !ok {
+			continue
+		}
+		if (b.Name == "main" || b.Name == "master" || b.Name == "trunk") &&
+			(b.Remote == "origin" || b.Remote == "upstream") {
+			possible = append(possible, b)
+		}
+	}
+	switch {
+	case len(possible) == 0:
+		return jujutsu.RefSymbol{}, fmt.Errorf("resolve trunk(): no suitable bookmarks found")
+	case len(possible) > 1:
+		// TODO(maybe): Jujutsu uses the latest(...) revset function
+		// to disambiguate.
+		// This requires a `jj log` for us, and it's unclear whether this is desirable.
+		// For now, just return an error, and make the user set a trunk().
+		sb := new(strings.Builder)
+		sb.WriteString("resolve trunk(): multiple found (")
+		for i, b := range bookmarks {
+			if i > 0 {
+				sb.WriteString("|")
+			}
+			sb.WriteString(b.RefSymbol().String())
+		}
+		sb.WriteString(")")
+		return jujutsu.RefSymbol{}, errors.New(sb.String())
+	}
+	return possible[0].RefSymbol(), nil
 }
 
 // nameForCommit finds a single local bookmark name for the given commit ID

--- a/jj_helpers_test.go
+++ b/jj_helpers_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Roxy Light and Benjamin Pollack
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next
+// paragraph) shall be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+// OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+// OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	"github.com/go-json-experiment/json/jsontext"
+	"zombiezen.com/go/jj-domino/internal/jujutsu"
+)
+
+func TestResolveTrunk(t *testing.T) {
+	fakeCommitID := jujutsu.CommitID{0xde, 0xad, 0xbe, 0xef}
+
+	tests := []struct {
+		name      string
+		settings  map[string]jsontext.Value
+		bookmarks []*jujutsu.Bookmark
+		want      jujutsu.RefSymbol
+		err       bool
+	}{
+		{
+			name: "Nothing",
+			err:  true,
+		},
+		{
+			name: "NoRemote",
+			bookmarks: []*jujutsu.Bookmark{
+				{Name: "foo", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+				{Name: "bar", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+			},
+			err: true,
+		},
+		{
+			name: "Implicit",
+			bookmarks: []*jujutsu.Bookmark{
+				{Name: "foo", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+				{Name: "bar", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+				{Name: "main", Remote: "origin", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+			},
+			want: jujutsu.RefSymbol{Name: "main", Remote: "origin"},
+		},
+		{
+			name: "ExplicitlySetLocal",
+			settings: map[string]jsontext.Value{
+				`revset-aliases."trunk()"`: jsontext.Value(`"foo"`),
+			},
+			bookmarks: []*jujutsu.Bookmark{
+				{Name: "foo", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+				{Name: "bar", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+				{Name: "main", Remote: "origin", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+			},
+			want: jujutsu.RefSymbol{Name: "foo"},
+		},
+		{
+			name: "ExplicitlySetRemote",
+			settings: map[string]jsontext.Value{
+				`revset-aliases."trunk()"`: jsontext.Value(`"foo@origin"`),
+			},
+			bookmarks: []*jujutsu.Bookmark{
+				{Name: "bar", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+				{Name: "main", Remote: "origin", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+				{Name: "foo", Remote: "origin", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+			},
+			want: jujutsu.RefSymbol{Name: "foo", Remote: "origin"},
+		},
+		{
+			name: "AmbiguousDefault",
+			bookmarks: []*jujutsu.Bookmark{
+				{Name: "main", Remote: "origin", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+				{Name: "trunk", Remote: "origin", TargetMerge: jujutsu.Resolved(fakeCommitID)},
+			},
+			err: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := resolveTrunk(test.settings, test.bookmarks)
+			if !test.err && (got != test.want || err != nil) {
+				t.Errorf("resolveTrunk(...) = %v, %v; want %v, <nil>", got, err, test.want)
+			} else if test.err && err == nil {
+				t.Errorf("resolveTrunk(...) = %v, <nil>; want _, <error>", got)
+			}
+		})
+	}
+}

--- a/submit.go
+++ b/submit.go
@@ -100,17 +100,17 @@ func (c *submitCmd) Run(ctx context.Context, k *kong.Kong, global *cli) error {
 			return fmt.Errorf("--base=%s does not have an associated remote", c.Base)
 		}
 	} else {
-		var trunkRevset string
-		if err := jsonv2.Unmarshal(jjSettings[`revset-aliases."trunk()"`], &trunkRevset); err != nil {
-			return fmt.Errorf("trunk: %v", err)
-		}
-		var err error
-		baseRef, err = jujutsu.ParseRefSymbol(trunkRevset)
+		// TODO(someday): Deduplicate bookmark listing.
+		bookmarks, err := jj.ListBookmarks(ctx)
 		if err != nil {
-			return fmt.Errorf("trunk %q: %v", trunkRevset, err)
+			return err
+		}
+		baseRef, err = resolveTrunk(jjSettings, bookmarks)
+		if err != nil {
+			return err
 		}
 		if baseRef.Remote == "" {
-			return fmt.Errorf("trunk() does not have an associated remote")
+			return fmt.Errorf("trunk() (%v) does not have an associated remote", baseRef)
 		}
 	}
 


### PR DESCRIPTION
Check bookmarks for well-known names in case the alias is not defined.

Fixes #47